### PR TITLE
fix: persist chat name changes by exposing rename function

### DIFF
--- a/src/context/Context.jsx
+++ b/src/context/Context.jsx
@@ -650,6 +650,7 @@ const ContextProvider = (props) => {
             verifyAssistantAt: contextValue.verifyAssistantAt,
             pinSession: contextValue.pinSession,
             renameSession: contextValue.renameSession,
+            renameSessionWithValue: contextValue.renameSessionWithValue,
             deleteSession: contextValue.deleteSession,
         };
     }


### PR DESCRIPTION
The chat renaming feature was not working correctly because the `renameSessionWithValue` function, which handles persisting the new name to the database, was not exposed on the global `window.appCtx` object. This meant the function was never called, and the name change was only reflected in the local component state, leading to it being reverted on re-render.

This commit fixes the issue by adding `renameSessionWithValue` to the `window.appCtx` object in `src/context/Context.jsx`, making it accessible to the sidebar component and ensuring that name changes are correctly persisted.